### PR TITLE
fix:パスワードリセットのメール文の訂正

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,8 @@
+Hello <%= @resource.email %>!
+
+Someone has requested a link to change your password. You can do this through the link below.
+
+<%= edit_password_url(@resource, reset_password_token: @token) %>
+
+If you didn't request this, please ignore this email.
+Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -48,9 +48,11 @@
         </div>
 
         <!-- リンク -->
+        <!--
         <div class="pt-4 border-t border-gray-200 space-y-3">
-          <%= render "devise/shared/links" %>
+          <%#= render "devise/shared/links" %>
         </div>
+        -->
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
メールをHTMLからTEXTへ変更。passwords/edit.html.erbの下部リンクを削除