### PR TITLE
add:酒・食べ物の複数登録機能の実装

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -8,42 +8,47 @@ class Shop < ApplicationRecord
     has_many :foods, through: :shop_foods
     has_many :shop_places, dependent: :destroy
 
-    accepts_nested_attributes_for :shop_sakes, allow_destroy: true
-    accepts_nested_attributes_for :shop_foods, allow_destroy: true
-    accepts_nested_attributes_for :sakes
-    accepts_nested_attributes_for :foods
     accepts_nested_attributes_for :shop_places
 
-    before_validation :find_or_assign_existing_sakes
-    before_validation :find_or_assign_existing_foods
+    attr_accessor :sake_names_input, :food_names_input
 
     def self.ransackable_attributes(auth_object = nil)
         %w[id name introduction created_at updated_at]
     end
 
     def self.ransackable_associations(auth_object = nil)
-        %w[posts sakes foods]
+        %w[posts sakes foods shop_places]
     end
 
-    private
+    # スペース区切りの文字列から酒のタグを更新
+    def update_sake_tags(sake_names_string)
+        return if sake_names_string.nil?
 
-    def find_or_assign_existing_sakes
-    self.sakes = sakes.map do |sake|
-        if sake.name.present?
-        Sake.find_by(name: sake.name) || sake
-        else
-        sake
+        # 全角・半角スペースで分割
+        sake_names = sake_names_string.split(/[[:space:]]+/).reject(&:blank?)
+
+        # 新しいsakeのIDリストを作成
+        new_sake_ids = sake_names.map do |name|
+            Sake.find_or_create_by!(name: name).id
         end
-    end
+
+        # 既存の関連を完全に置き換え
+        self.sake_ids = new_sake_ids
     end
 
-    def find_or_assign_existing_foods
-    self.foods = foods.map do |food|
-        if food.name.present?
-        Food.find_by(name: food.name) || food
-        else
-        food
+    # スペース区切りの文字列から料理のタグを更新
+    def update_food_tags(food_names_string)
+        return if food_names_string.nil?
+
+        # 全角・半角スペースで分割
+        food_names = food_names_string.split(/[[:space:]]+/).reject(&:blank?)
+
+        # 新しいfoodのIDリストを作成
+        new_food_ids = food_names.map do |name|
+            Food.find_or_create_by!(name: name).id
         end
-    end
+
+        # 既存の関連を完全に置き換え
+        self.food_ids = new_food_ids
     end
 end

--- a/app/models/shop_place.rb
+++ b/app/models/shop_place.rb
@@ -1,3 +1,11 @@
 class ShopPlace < ApplicationRecord
     belongs_to :shop
+
+    def self.ransackable_attributes(auth_object = nil)
+        %w[id address created_at updated_at shop_id]
+    end
+
+    def self.ransackable_associations(auth_object = nil)
+        %w[shop]
+    end
 end

--- a/app/views/posts/_search.html.erb
+++ b/app/views/posts/_search.html.erb
@@ -12,7 +12,7 @@
           </div>
 
           <!-- 検索フィールド -->
-          <%= f.search_field :shop_name_or_shop_sakes_name_or_shop_foods_name_cont,
+          <%= f.search_field :shop_name_or_shop_sakes_name_or_shop_foods_name_or_shop_shop_places_address_cont,
               placeholder: t('posts.search_placeholder'),
               class: "flex-1 text-gray-700 placeholder-gray-400 focus:outline-none text-base sm:text-lg min-w-0" %>
         </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -26,20 +26,18 @@
           <% end %>
 
           <h4 class="text-lg font-semibold text-gray-800 mb-3 border-b pb-2">お酒</h4>
-          <%= shop_fields.fields_for :sakes do |sake_fields| %>
-            <div class="mb-3">
-              <%= sake_fields.label :name, "お酒の名前", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= sake_fields.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
-            </div>
-          <% end %>
+          <div class="mb-3">
+            <%= shop_fields.label :sake_names_input, "酒名（複数の場合はスペース区切り）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= shop_fields.text_field :sake_names_input, placeholder: "例: 獺祭 八海山 久保田", class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+            <p class="text-xs text-gray-500 mt-1">※複数登録する場合は、全角または半角スペースで区切ってください</p>
+          </div>
 
           <h4 class="text-lg font-semibold text-gray-800 mb-3 mt-6 border-b pb-2">料理</h4>
-          <%= shop_fields.fields_for :foods do |food_fields| %>
-            <div class="mb-3">
-              <%= food_fields.label :name, "料理の名前", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= food_fields.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
-            </div>
-          <% end %>
+          <div class="mb-3">
+            <%= shop_fields.label :food_names_input, "料理名（複数の場合はスペース区切り）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= shop_fields.text_field :food_names_input, placeholder: "例: 刺身 焼き鳥 天ぷら", class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+            <p class="text-xs text-gray-500 mt-1">※複数登録する場合は、全角または半角スペースで区切ってください</p>
+          </div>
         </div>
       <% end %>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -24,20 +24,18 @@
           <% end %>
 
           <h4 class="text-lg font-semibold text-gray-800 mb-3 border-b pb-2">お酒</h4>
-          <%= shop_fields.fields_for :sakes do |sake_fields| %>
-            <div class="mb-3">
-              <%= sake_fields.label :name, "酒名", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= sake_fields.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
-            </div>
-          <% end %>
+          <div class="mb-3">
+            <%= shop_fields.label :sake_names_input, "酒名（複数の場合はスペース区切り）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= shop_fields.text_field :sake_names_input, placeholder: "例: 獺祭 八海山 久保田", class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+            <p class="text-xs text-gray-500 mt-1">※複数登録する場合は、全角または半角スペースで区切ってください</p>
+          </div>
 
           <h4 class="text-lg font-semibold text-gray-800 mb-3 mt-6 border-b pb-2">料理</h4>
-          <%= shop_fields.fields_for :foods do |food_fields| %>
-            <div class="mb-3">
-              <%= food_fields.label :name, "料理名", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= food_fields.text_field :name, class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
-            </div>
-          <% end %>
+          <div class="mb-3">
+            <%= shop_fields.label :food_names_input, "料理名（複数の場合はスペース区切り）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= shop_fields.text_field :food_names_input, placeholder: "例: 刺身 焼き鳥 天ぷら", class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" %>
+            <p class="text-xs text-gray-500 mt-1">※複数登録する場合は、全角または半角スペースで区切ってください</p>
+          </div>
         </div>
       <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,26 +28,36 @@
       <% end %>
 
       <!-- Sakes -->
-      <h4 class="text-lg font-semibold text-gray-800 mb-2">Sakes</h4>
-      <% @post.shop.sakes.each do |sake| %>
-        <div class="mb-3">
-          <label class="block text-sm font-medium text-gray-700">Sake Name</label>
-          <div class="bg-gray-100 border border-gray-300 text-gray-900 text-sm rounded-lg p-2.5 w-full">
-            <%= sake.name %>
+      <div class="mb-4">
+        <h4 class="text-lg font-semibold text-gray-800 mb-2 border-b pb-2">お酒</h4>
+        <% if @post.shop.sakes.any? %>
+          <div class="flex flex-wrap gap-2">
+            <% @post.shop.sakes.each do |sake| %>
+              <span class="inline-block bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full">
+                <%= sake.name %>
+              </span>
+            <% end %>
           </div>
-        </div>
-      <% end %>
+        <% else %>
+          <p class="text-gray-500 text-sm">登録されていません</p>
+        <% end %>
+      </div>
 
       <!-- Foods -->
-      <h4 class="text-lg font-semibold text-gray-800 mb-2 mt-4">Foods</h4>
-      <% @post.shop.foods.each do |food| %>
-        <div class="mb-3">
-          <label class="block text-sm font-medium text-gray-700">Food Name</label>
-          <div class="bg-gray-100 border border-gray-300 text-gray-900 text-sm rounded-lg p-2.5 w-full">
-            <%= food.name %>
+      <div class="mb-4">
+        <h4 class="text-lg font-semibold text-gray-800 mb-2 border-b pb-2">料理</h4>
+        <% if @post.shop.foods.any? %>
+          <div class="flex flex-wrap gap-2">
+            <% @post.shop.foods.each do |food| %>
+              <span class="inline-block bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full">
+                <%= food.name %>
+              </span>
+            <% end %>
           </div>
-        </div>
-      <% end %>
+        <% else %>
+          <p class="text-gray-500 text-sm">登録されていません</p>
+        <% end %>
+      </div>
     </div>
 
     <!-- Comment -->


### PR DESCRIPTION
タグ機能の実装。
当初Sake_tags・Food_tags、Sake_maps・Food_mapsの中間テーブル含め4テーブルを新規作成予定でしたが、既存テーブルで実現可能なため変更。酒、料理の区切りはスペースでフレーズを判定しています。